### PR TITLE
fix: bug on Visualization intersection_features, that's self.data_idx

### DIFF
--- a/postprocess/visualization.py
+++ b/postprocess/visualization.py
@@ -74,9 +74,8 @@ class Visualization(object):
         :param threshold: threshold for the bootstrap probability to accept an edge.
         """
         self.global_state = global_state
-        
-        intersection_features = list(set(global_state.user_data.processed_data.columns).intersection(
-            set(global_state.user_data.visual_selected_features)))
+
+        intersection_features = list(global_state.user_data.visual_selected_features)
         self.data = global_state.user_data.processed_data[intersection_features]
         self.data_idx = [global_state.user_data.processed_data.columns.get_loc(var) for var in intersection_features]
         self.bootstrap_prob = global_state.results.bootstrap_probability


### PR DESCRIPTION
I think it is a bug and fix it in this PR.

reason: the orig code as below, the intersection_features is random because of set() operation. In the later boot_heatmap_plot func inside Visualization, the  xticklabels and yticklabels are fixed visual_selected_features. So the boot_heatmap_plot is wrong!.
It is safe to directly use visual_selected_features as the intersection_features. 

```python
class Visualization(object):
    def __init__(self, global_state, threshold: float=0.95):
        """
        :param global_state: a dict containing global variables and information
        :param args: arguments for the report generation
        :param threshold: threshold for the bootstrap probability to accept an edge.
        """
        self.global_state = global_state
        
        intersection_features = list(set(global_state.user_data.processed_data.columns).intersection(
            set(global_state.user_data.visual_selected_features)))
        self.data = global_state.user_data.processed_data[intersection_features]
        self.data_idx = [global_state.user_data.processed_data.columns.get_loc(var) for var in intersection_features]
```

```python
    def boot_heatmap_plot(self):
        
        # Ensure save directory exists
        if not os.path.exists(self.save_dir):
            os.makedirs(self.save_dir, exist_ok=True)
            logger.debug(f"Created save directory: {self.save_dir}", "Visualization")
        
        boot_prob_dict = {k: v for k, v in self.bootstrap_prob.items() if v is not None and sum(v.flatten())>0}
        name_map = {'certain_edges': 'Directed Edge', #(->)
                    'uncertain_edges': 'Undirected Edge', #(-)
                    'bi_edges': 'Bi-Directed Edge', #(<->)
                    'half_certain_edges': 'Directed Non-Ancestor Edge', #(o->)
                    'half_uncertain_edges': 'Undirected Non-Ancestor Edge', #(o-)
                    'none_edges': 'No D-Seperation Edge', #(o-o)
                    'none_existence':'No Edge'}
        paths = []
        for key in boot_prob_dict.keys():
            try:
                prob_mat = boot_prob_dict[key]
                name = name_map[key]
                # Create a heatmap
                plt.figure(figsize=(8, 6))
                #plt.rcParams['font.family'] = 'Times New Roman'
                sns.heatmap(prob_mat[self.data_idx, :][:, self.data_idx], annot=True, cmap='Reds', fmt=".2f", square=True, cbar_kws={"shrink": .8},
                            xticklabels=self.global_state.user_data.visual_selected_features,
                            yticklabels=self.global_state.user_data.visual_selected_features)
```