### PR TITLE
fix: add missing python-multipart and groovy to requirements_cpu.txt

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -122,7 +122,8 @@ colorama==0.4.6
 dask==2025.2.0
 cloudpickle==3.1.1
 causalnex==0.12.1
-
+python-multipart==0.0.22
+groovy==0.1.2
 
 econml==0.15.1
 sparse==0.16.0


### PR DESCRIPTION
When running the web demo, I got errors related to these two missing requirements. web_demo/demo.py worked once they were added. 